### PR TITLE
Modified for Scala 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,18 @@
 	<groupId>suereth</groupId>
 	<artifactId>embedded-interpreter</artifactId>
 	<packaging>jar</packaging>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.1-2.8.1</version>
 	<url>http://suereth.blogspot.com</url>
 	<repositories>
 		<repository>
 			<id>scala-tools.org</id>
 			<name>Scala-tools Maven2 Repository</name>
 			<url>http://scala-tools.org/repo-snapshots</url>
+		</repository>
+		<repository>
+			<id>jline</id>
+			<name>JLine Project Repository</name>
+			<url>http://jline.sourceforge.net/m2repo</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
@@ -24,13 +29,18 @@
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-compiler</artifactId>
-			<version>2.7.3</version>
+			<version>2.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.5</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jline</groupId>
+			<artifactId>jline</artifactId>
+			<version>0.9.9</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/scala/test/InterpreterWrapper.scala
+++ b/src/main/scala/test/InterpreterWrapper.scala
@@ -21,9 +21,9 @@ import scala.reflect._
 trait InterpreterWrapper {
 
   private var bindings : Map[String, (java.lang.Class[_], AnyRef)] = Map()
-  private var packageImports : List[String] = List()  
+  private var packageImports : List[String] = List()
   private var files = List[String]()
-  
+
   /**
    * Binds a given value into the interpreter when it starts with its most specific class
    */
@@ -36,61 +36,69 @@ trait InterpreterWrapper {
   protected def bindAs[A <: AnyRef, B <: A](name : String, interface : java.lang.Class[A], value : B) {
     bindings += ((name,  (interface, value)))
   }
-  
+
   /**
    * adds an auto-import for the interpreter.
    */
   protected def autoImport(importString : String) {
     packageImports = importString :: packageImports
   }
-  
+
   /**
    * Adds a file that will be interpreter at the start of the interpreter
    */
   protected def addScriptFile(fileName : String) {
     files = fileName :: files
   }
-  
+
   def helpMsg : String
   def welcomeMsg : String
   def prompt : String
-  
+
   /**
    * This class actually runs the interpreter loop.
    */
   class MyInterpreterLoop(out : PrintWriter) extends InterpreterLoop(None, out) {
      override val prompt = InterpreterWrapper.this.prompt
-    
-     override def bindSettings() {       
-       super.bindSettings()      
+
+     // In Scala 2.8, InterpreterLoop.bindSettings() has been removed.
+     // So, I need to override repl() and bind my settings by myself.
+     override def repl() {
+    	 bindSettings()
+    	 super.repl()
+     }
+
+     /** Bind the settings so that evaluated code can modify them */
+     def bindSettings() {
        interpreter beQuietDuring {
          for( (name, (clazz, value)) <- bindings) {
            interpreter.bind(name, clazz.getCanonicalName, value)
          }
          for( importString <- packageImports) {
         	 interpreter.interpret("import " + importString)
-         } 
+         }
        }
      }
+
     override def printHelp {
        printWelcome()
        out.println(helpMsg)
        out.flush()
      }
-     
+
      override def printWelcome() {
        out.println(welcomeMsg)
        out.flush()
      }
   }
-  
+
   def startInterpreting() {
     val out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.out)))
     val settings = new GenericRunnerSettings(out.println _)
     files.foreach(settings.loadfiles.appendToValue)
     //Below for 2.8.0-SNAPSHOT
     //settings.completion.value = true
-    
+
     val interpreter = new MyInterpreterLoop(out)
     interpreter.main(settings)
     ()


### PR DESCRIPTION
Hello, 

I modified your interpreter sample to work with Scala 2.8.
Then, I would like to give you some feedback.

The change log is bellow.
- Modified for Scala 2.8.
  As InterpreterLoop of Scala 2.8 no longer has bindSettings(), overrided repl() to call our  bindSettings().
- Built with Scala 2.8.1.
